### PR TITLE
Add dev config and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Fonts: Intro Cond
 * Install the bundler gem: `gem install bundler`
 * Head to the root directory in your command prompt
 * Run `bundle install`. The github pages gems will install.
-* Run `bundle exec jekyll serve`. This will serve the page at `http://localhost:4000`
-
+* Run `bundle exec jekyll serve --config _config.yml,_config.dev.yml` . This will serve the page at `http://localhost:4000`
+ * If you omit the `--config` references, all URLs will reference the prod site, which may be confusing.
+ * This refernece means that the standard `_config.yml` is used first, and then overriden with the values in `_config.dev.yml`.
 If you run into problems, feel free to reach out to [Sean Killeen](mailto:SeanKilleen@gmail.com) or find us on the [dotNetFringe Slack org](https://dotnetfringe.slack.com/)
 
 ## Troubleshooting: Regeneration throws an SSL Error

--- a/_config.dev.yml
+++ b/_config.dev.yml
@@ -1,0 +1,3 @@
+# Site wide configuration
+
+url:              http://localhost:4000


### PR DESCRIPTION
We needed to add the URL to the production site so it could be served, but also needed to overwrite the URL field with `localhost` when we're local. Thus, Jekyll configs come into play.

This changes the URL to be correct and updates the `README` to indicate how to utilize it.